### PR TITLE
Fix section name style & marginBottom on inBody ad

### DIFF
--- a/packages/global/scss/components/blocks/_load-analyzer-inbody.scss
+++ b/packages/global/scss/components/blocks/_load-analyzer-inbody.scss
@@ -3,6 +3,7 @@
   $self: &;
   height: 100%;
   padding: 24px 24px 0 24px ;
+  margin-bottom: map-get($spacers, block);
   background-color: $gray-100;
   display: flex;
   flex-direction: column;
@@ -38,6 +39,12 @@
         }
       }
     }
+  }
+
+  &__website-section-name {
+    @include skin-typography($style: "slug-small", $link-style: "primary");
+    display: block;
+    margin-bottom: 12px;
   }
 
   &__description {


### PR DESCRIPTION
<img width="1137" alt="Screenshot 2024-12-09 at 9 29 28 AM" src="https://github.com/user-attachments/assets/611ddfa6-0d77-40e7-8cbe-0666048209ea">
